### PR TITLE
Fix for Ubuntu 20.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ clean: delpyc
 	rm -Rf bin include lib local node_modules compass/.sass-cache
 
 install:
-	virtualenv --no-site-packages .
-	bin/pip install -r pip-requirements/basic.txt
-	bin/pip install psutil
-	bin/python manage.py migrate
+	virtualenv --python=/usr/bin/python2.7 .
+	python2.7 -m pip install -r pip-requirements/basic.txt
+	python2.7 -m pip install psutil
+	python2.7 manage.py migrate
 
 install-dev: install
 	bundle install --gemfile=compass/Gemfile


### PR DESCRIPTION
See here:

https://github.com/RetroPie/RetroPie-Setup/issues/3256#issuecomment-793107448

---

This is the fix for the Makefile for users running Ubuntu 20.04:

```
	virtualenv --python=/usr/bin/python2.7 .
	python2.7 -m pip install -r pip-requirements/basic.txt
	python2.7 -m pip install psutil
	python2.7 manage.py migrate
```
	
Prior to running the Makefile, pip will need to be installed in Python 2.7. You can do that simply by running the following:

```
curl https://bootstrap.pypa.io/pip/2.7/get-pip.py  --output get-pip.py
sudo python2.7 get-pip.py
```

To any users casually reading this, there are no warranties or promises. I have, however, confirmed it works perfectly for my specific system configuration (HP T640 with Ryzen R1505G running Ubuntu 20.04 LTS 64-bit).