### PR TITLE
Delete include directory

### DIFF
--- a/include/python2.7
+++ b/include/python2.7
@@ -1,1 +1,0 @@
-/usr/include/python2.7


### PR DESCRIPTION
Please remove this directory to make this repo buildable across all platforms. This is created by your system for its unique architecture and configuration for its virtual environment. Anyone who uses this repo like myself has to manually delete this before they can build if their build environment is different from yours. Otherwise, make install will fail, which is why I incorrectly resorted to using global Python beforehand. (As a side note, as you had noticed, I was wrong to use global Python in the makefile like I did. Global Python does not work properly when called by the running process which causes the monitoring page to not work. This is why running Python from the local bin folder in the makefile after initially creating the virtual environment is the correct approach, which you had fixed.) You will notice that is why RetroPie/RetroPie-Manager does not have the share, bin, lib, and include folders.