### PR TITLE
Fix repository URL in skeleton.html

### DIFF
--- a/project/templates/skeleton.html
+++ b/project/templates/skeleton.html
@@ -42,7 +42,7 @@
 
             <div class="top-bar-section">
                 <ul class="right social-badges">
-                    <li><a href="https://github.com/botolo78/RetroPie-Manager" target="_blank"><i class="icon-github-square"></i></a></li>
+                    <li><a href="https://github.com/RetroPie/RetroPie-Manager" target="_blank"><i class="icon-github-square"></i></a></li>
                 </ul>
 
                 <ul class="left">


### PR DESCRIPTION
If this is integrated into the main branch for RetroPie-Manager (https://github.com/RetroPie/RetroPie-Manager), we will want to match this pull request (https://github.com/RetroPie/RetroPie-Manager/commit/ae65d7e5970b96e669db8815bcc12970ccbf643c) that updates this URL from the old abandoned repo to RetroPie's repo.